### PR TITLE
Update XComEncounterLists.ini

### DIFF
--- a/LongWarOfTheChosen/Config/XComEncounterLists.ini
+++ b/LongWarOfTheChosen/Config/XComEncounterLists.ini
@@ -100,15 +100,15 @@
 	SpawnDistribution[7]=(Template="AdvCaptainM1", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=1, SpawnWeight=1), \\
 )
 
-+SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
-	SpawnDistribution[0]=(Template="AdvCaptainM1", MinForceLevel=1, MaxForceLevel=1, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[1]=(Template="AdvCaptainM1", MinForceLevel=2, MaxForceLevel=2, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[2]=(Template="AdvCaptainM1", MinForceLevel=3, MaxForceLevel=3, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[3]=(Template="AdvCaptainM1", MinForceLevel=4, MaxForceLevel=4, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[4]=(Template="AdvCaptainM1", MinForceLevel=5, MaxForceLevel=5, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[5]=(Template="AdvCaptainM1", MinForceLevel=6, MaxForceLevel=6, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[6]=(Template="AdvCaptainM1", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=1, SpawnWeight=2), \\
-	SpawnDistribution[7]=(Template="AdvCaptainM1", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=1, SpawnWeight=1), \\
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="AdvCaptainM1", MinForceLevel=1, MaxForceLevel=1, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[1]=(Template="AdvCaptainM1", MinForceLevel=2, MaxForceLevel=2, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[2]=(Template="AdvCaptainM1", MinForceLevel=3, MaxForceLevel=3, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[3]=(Template="AdvCaptainM1", MinForceLevel=4, MaxForceLevel=4, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[4]=(Template="AdvCaptainM1", MinForceLevel=5, MaxForceLevel=5, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[5]=(Template="AdvCaptainM1", MinForceLevel=6, MaxForceLevel=6, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[6]=(Template="AdvCaptainM1", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[7]=(Template="AdvCaptainM1", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 )
 
 ;--------------------------
@@ -180,13 +180,13 @@
 	SpawnDistribution[7]=(Template="AdvCaptainM2", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=1, SpawnWeight=1), \\
 )
 
-+SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
 	SpawnDistribution[0]=(Template="AdvCaptainM2", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=1, SpawnWeight=1), \\
 	SpawnDistribution[1]=(Template="AdvCaptainM2", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 	SpawnDistribution[2]=(Template="AdvCaptainM2", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[3]=(Template="AdvCaptainM2", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[4]=(Template="AdvCaptainM2", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=1, SpawnWeight=3), \\
-	SpawnDistribution[5]=(Template="AdvCaptainM2", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="AdvCaptainM2", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[4]=(Template="AdvCaptainM2", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[5]=(Template="AdvCaptainM2", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=1, SpawnWeight=4), \\
 	SpawnDistribution[6]=(Template="AdvCaptainM2", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 	SpawnDistribution[7]=(Template="AdvCaptainM2", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=1, SpawnWeight=1), \\
 )
@@ -260,7 +260,7 @@
 	SpawnDistribution[7]=(Template="AdvCaptainM3", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=5), \\
 )
 
-+SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
 	SpawnDistribution[0]=(Template="AdvCaptainM3", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=1, SpawnWeight=1), \\
 	SpawnDistribution[1]=(Template="AdvCaptainM3", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 	SpawnDistribution[2]=(Template="AdvCaptainM3", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=1, SpawnWeight=3), \\
@@ -1957,6 +1957,15 @@
 	SpawnDistribution[5]=(Template="AdvPriestM1", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 	SpawnDistribution[6]=(Template="AdvPriestM1", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=1, SpawnWeight=1), \\
 )
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="AdvPriestM1", MinForceLevel=3, MaxForceLevel=3, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="AdvPriestM1", MinForceLevel=4, MaxForceLevel=4, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="AdvPriestM1", MinForceLevel=5, MaxForceLevel=5, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="AdvPriestM1", MinForceLevel=6, MaxForceLevel=6, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[4]=(Template="AdvPriestM1", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[5]=(Template="AdvPriestM1", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[6]=(Template="AdvPriestM1", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+)
 
 ;--------------------------
 ; AdvPriestM2
@@ -2106,6 +2115,18 @@
 	SpawnDistribution[10]=(Template="AdvPriestM2", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 	SpawnDistribution[11]=(Template="AdvPriestM2", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 )
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="AdvPriestM2", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="AdvPriestM2", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="AdvPriestM2", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="AdvPriestM2", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[4]=(Template="AdvPriestM2", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[5]=(Template="AdvPriestM2", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[6]=(Template="AdvPriestM2", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[7]=(Template="AdvPriestM2", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[8]=(Template="AdvPriestM2", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+	SpawnDistribution[9]=(Template="AdvPriestM2", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+)
 
 ;--------------------------
 ; AdvPriestM3
@@ -2201,7 +2222,15 @@
 	SpawnDistribution[4]=(Template="AdvPriestM3", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=1, SpawnWeight=6), \\
 	SpawnDistribution[5]=(Template="AdvPriestM3", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=6), \\
 )
-
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="AdvPriestM3", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="AdvPriestM3", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="AdvPriestM3", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="AdvPriestM3", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[4]=(Template="AdvPriestM3", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[5]=(Template="AdvPriestM3", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[6]=(Template="AdvPriestM3", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+)
 ;--------------------------
 ; AdvPsiWitchM3
 ;
@@ -4870,6 +4899,27 @@
 	SpawnDistribution[4]=(Template="Archon", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=5), \\
 	SpawnDistribution[5]=(Template="Archon", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=6), \\
 )
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="Archon", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="Archon", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[2]=(Template="Archon", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="Archon", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="Archon", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[5]=(Template="Archon", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[6]=(Template="Archon", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[7]=(Template="Archon", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[8]=(Template="Archon", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[9]=(Template="Archon", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+)
+
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="Archon", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="Archon", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="Archon", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="Archon", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="Archon", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[5]=(Template="Archon", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+)
 
 ;--------------------------
 ; ArchonM2_LW
@@ -4921,7 +4971,18 @@
 	SpawnDistribution[0]=(Template="ArchonM2_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=2, SpawnWeight=2), \\
 	SpawnDistribution[1]=(Template="ArchonM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=2, SpawnWeight=4), \\
 )
-
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="ArchonM2_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+	SpawnDistribution[1]=(Template="ArchonM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+)
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="ArchonM2_LW", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=2, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="ArchonM2_LW", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="ArchonM2_LW", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="ArchonM2_LW", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="ArchonM2_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+	SpawnDistribution[5]=(Template="ArchonM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+)
 ;--------------------------
 ; Berserker
 ;
@@ -5234,20 +5295,20 @@
 )
 
 +SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
-	SpawnDistribution[0]=(Template="Faceless", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[1]=(Template="Faceless", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[2]=(Template="Faceless", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[3]=(Template="Faceless", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[4]=(Template="Faceless", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[5]=(Template="Faceless", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[6]=(Template="Faceless", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[7]=(Template="Faceless", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[8]=(Template="Faceless", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[9]=(Template="Faceless", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[10]=(Template="Faceless", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[11]=(Template="Faceless", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[12]=(Template="Faceless", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=8, SpawnWeight=2), \\
-	SpawnDistribution[13]=(Template="Faceless", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=8, SpawnWeight=2), \\
+	SpawnDistribution[0]=(Template="Faceless", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[1]=(Template="Faceless", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="Faceless", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="Faceless", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="Faceless", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[5]=(Template="Faceless", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[6]=(Template="Faceless", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[7]=(Template="Faceless", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[8]=(Template="Faceless", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[9]=(Template="Faceless", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[10]=(Template="Faceless", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[11]=(Template="Faceless", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[12]=(Template="Faceless", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[13]=(Template="Faceless", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=2), \\
 )
 
 ;--------------------------
@@ -5798,7 +5859,20 @@
 	SpawnDistribution[8]=(Template="MutonM2_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=2, SpawnWeight=12), \\
 	SpawnDistribution[9]=(Template="MutonM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=2, SpawnWeight=12), \\
 )
-
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="MutonM2_LW", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=2, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="MutonM2_LW", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="MutonM2_LW", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=2, SpawnWeight=4), \\
+	SpawnDistribution[3]=(Template="MutonM2_LW", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=2, SpawnWeight=6), \\
+	SpawnDistribution[4]=(Template="MutonM2_LW", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=2, SpawnWeight=6), \\
+	SpawnDistribution[5]=(Template="MutonM2_LW", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=2, SpawnWeight=6), \\
+	SpawnDistribution[6]=(Template="MutonM2_LW", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=2, SpawnWeight=6), \\
+	SpawnDistribution[7]=(Template="MutonM2_LW", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=2, SpawnWeight=6), \\
+	SpawnDistribution[8]=(Template="MutonM2_LW", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=2, SpawnWeight=5), \\
+	SpawnDistribution[9]=(Template="MutonM2_LW", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=2, SpawnWeight=5), \\
+	SpawnDistribution[10]=(Template="MutonM2_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=2, SpawnWeight=5), \\
+	SpawnDistribution[11]=(Template="MutonM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=2, SpawnWeight=5), \\
+)
 ;--------------------------
 ; MutonM3_LW
 ;
@@ -5878,6 +5952,14 @@
 	SpawnDistribution[5]=(Template="MutonM3_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=2, SpawnWeight=8), \\
 )
 
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="MutonM3_LW", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=2, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="MutonM3_LW", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="MutonM3_LW", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=2, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="MutonM3_LW", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=2, SpawnWeight=5), \\
+	SpawnDistribution[4]=(Template="MutonM3_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=2, SpawnWeight=6), \\
+	SpawnDistribution[5]=(Template="MutonM3_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=2, SpawnWeight=8), \\
+)
 ;--------------------------
 ; NajaM1
 ;
@@ -5982,7 +6064,27 @@
 	SpawnDistribution[9]=(Template="NajaM1", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=3, SpawnWeight=1), \\
 	SpawnDistribution[10]=(Template="NajaM1", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=3, SpawnWeight=1), \\
 )
-
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="NajaM1", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="NajaM1", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="NajaM1", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="NajaM1", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=3, SpawnWeight=5), \\
+	SpawnDistribution[4]=(Template="NajaM1", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=3, SpawnWeight=6), \\
+	SpawnDistribution[5]=(Template="NajaM1", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[6]=(Template="NajaM1", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[7]=(Template="NajaM1", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[8]=(Template="NajaM1", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[9]=(Template="NajaM1", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[10]=(Template="NajaM1", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+)
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="NajaM1", MinForceLevel=5, MaxForceLevel=5, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="NajaM1", MinForceLevel=6, MaxForceLevel=6, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[2]=(Template="NajaM1", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="NajaM1", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="NajaM1", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[5]=(Template="NajaM1", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+)
 ;--------------------------
 ; NajaM2
 ;
@@ -6077,7 +6179,26 @@
 	SpawnDistribution[7]=(Template="NajaM2", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=1), \\
 	SpawnDistribution[8]=(Template="NajaM2", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=1), \\
 )
-
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="NajaM2", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="NajaM2", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[2]=(Template="NajaM2", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="NajaM2", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="NajaM2", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[5]=(Template="NajaM2", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[6]=(Template="NajaM2", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+)
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="NajaM2", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[1]=(Template="NajaM2", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=3, SpawnWeight=5), \\
+	SpawnDistribution[2]=(Template="NajaM2", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=3, SpawnWeight=6), \\
+	SpawnDistribution[3]=(Template="NajaM2", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=3, SpawnWeight=5), \\
+	SpawnDistribution[4]=(Template="NajaM2", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=3, SpawnWeight=4), \\
+	SpawnDistribution[5]=(Template="NajaM2", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[6]=(Template="NajaM2", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[7]=(Template="NajaM2", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[8]=(Template="NajaM2", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+)
 ;--------------------------
 ; NajaM3
 ;
@@ -6132,7 +6253,19 @@
 	SpawnDistribution[1]=(Template="NajaM3", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=4), \\
 	SpawnDistribution[2]=(Template="NajaM3", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=4), \\
 )
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="NajaM3", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="NajaM3", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="NajaM3", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="NajaM3", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="NajaM3", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=1), \\
+)
 
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="NajaM3", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=3, SpawnWeight=4), \\
+	SpawnDistribution[1]=(Template="NajaM3", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=4), \\
+	SpawnDistribution[2]=(Template="NajaM3", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=4), \\
+)
 ;--------------------------
 ; Sectoid
 ;
@@ -6283,6 +6416,39 @@
 	SpawnDistribution[15]=(Template="Sectoid", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=4, SpawnWeight=8), \\
 	SpawnDistribution[16]=(Template="Sectoid", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=8), \\
 )
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="Sectoid", MinForceLevel=1, MaxForceLevel=1, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="Sectoid", MinForceLevel=2, MaxForceLevel=2, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[2]=(Template="Sectoid", MinForceLevel=3, MaxForceLevel=3, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="Sectoid", MinForceLevel=4, MaxForceLevel=4, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="Sectoid", MinForceLevel=5, MaxForceLevel=5, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[5]=(Template="Sectoid", MinForceLevel=6, MaxForceLevel=6, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[6]=(Template="Sectoid", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[7]=(Template="Sectoid", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[8]=(Template="Sectoid", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[9]=(Template="Sectoid", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[10]=(Template="Sectoid", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+)
+
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="Sectoid", MinForceLevel=4, MaxForceLevel=4, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[1]=(Template="Sectoid", MinForceLevel=5, MaxForceLevel=5, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[2]=(Template="Sectoid", MinForceLevel=6, MaxForceLevel=6, MaxCharactersPerGroup=4, SpawnWeight=5), \\
+	SpawnDistribution[3]=(Template="Sectoid", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=4, SpawnWeight=6), \\
+	SpawnDistribution[4]=(Template="Sectoid", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=4, SpawnWeight=7), \\
+	SpawnDistribution[5]=(Template="Sectoid", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=4, SpawnWeight=8), \\
+	SpawnDistribution[6]=(Template="Sectoid", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=4, SpawnWeight=7), \\
+	SpawnDistribution[7]=(Template="Sectoid", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=4, SpawnWeight=6), \\
+	SpawnDistribution[8]=(Template="Sectoid", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=4, SpawnWeight=6), \\
+	SpawnDistribution[9]=(Template="Sectoid", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=4, SpawnWeight=6), \\
+	SpawnDistribution[10]=(Template="Sectoid", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=4, SpawnWeight=6), \\
+	SpawnDistribution[11]=(Template="Sectoid", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=4, SpawnWeight=7), \\
+	SpawnDistribution[12]=(Template="Sectoid", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=4, SpawnWeight=8), \\
+	SpawnDistribution[13]=(Template="Sectoid", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=4, SpawnWeight=8), \\
+	SpawnDistribution[14]=(Template="Sectoid", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=4, SpawnWeight=8), \\
+	SpawnDistribution[15]=(Template="Sectoid", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=4, SpawnWeight=8), \\
+	SpawnDistribution[16]=(Template="Sectoid", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=8), \\
+)
 
 ;--------------------------
 ; SectoidM2_LW
@@ -6364,7 +6530,17 @@
 	SpawnDistribution[4]=(Template="SectoidM2_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=6), \\
 	SpawnDistribution[5]=(Template="SectoidM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=7), \\
 )
-
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="SectoidM2_LW", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[1]=(Template="SectoidM2_LW", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="SectoidM2_LW", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="SectoidM2_LW", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=3, SpawnWeight=2), \\
+	SpawnDistribution[4]=(Template="SectoidM2_LW", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[5]=(Template="SectoidM2_LW", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[6]=(Template="SectoidM2_LW", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[7]=(Template="SectoidM2_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+	SpawnDistribution[8]=(Template="SectoidM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=3, SpawnWeight=3), \\
+)
 ;--------------------------
 ; Sectopod
 ;
@@ -6480,6 +6656,18 @@
 	SpawnDistribution[9]=(Template="SidewinderM1", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=4, SpawnWeight=1), \\
 )
 
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="SidewinderM1", MinForceLevel=6, MaxForceLevel=6, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="SidewinderM1", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[2]=(Template="SidewinderM1", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=4, SpawnWeight=5), \\
+	SpawnDistribution[3]=(Template="SidewinderM1", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=4, SpawnWeight=5), \\
+	SpawnDistribution[4]=(Template="SidewinderM1", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+	SpawnDistribution[5]=(Template="SidewinderM1", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[6]=(Template="SidewinderM1", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[7]=(Template="SidewinderM1", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[8]=(Template="SidewinderM1", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[9]=(Template="SidewinderM1", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+)
 ;--------------------------
 ; SidewinderM2
 ;
@@ -6579,6 +6767,18 @@
 	SpawnDistribution[9]=(Template="SidewinderM2", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=1), \\
 )
 
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="SidewinderM2", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="SidewinderM2", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="SidewinderM2", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="SidewinderM2", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+	SpawnDistribution[4]=(Template="SidewinderM2", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=4, SpawnWeight=5), \\
+	SpawnDistribution[5]=(Template="SidewinderM2", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+	SpawnDistribution[6]=(Template="SidewinderM2", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[7]=(Template="SidewinderM2", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[8]=(Template="SidewinderM2", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[9]=(Template="SidewinderM2", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+)
 ;--------------------------
 ; SidewinderM3
 ;
@@ -6643,6 +6843,14 @@
 )
 
 +SpawnDistributionLists=(ListID="Open", \\
+	SpawnDistribution[0]=(Template="SidewinderM3", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[1]=(Template="SidewinderM3", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=4, SpawnWeight=6), \\
+	SpawnDistribution[2]=(Template="SidewinderM3", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+	SpawnDistribution[3]=(Template="SidewinderM3", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+	SpawnDistribution[4]=(Template="SidewinderM3", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+)
+
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
 	SpawnDistribution[0]=(Template="SidewinderM3", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=4, SpawnWeight=3), \\
 	SpawnDistribution[1]=(Template="SidewinderM3", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=4, SpawnWeight=6), \\
 	SpawnDistribution[2]=(Template="SidewinderM3", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=4, SpawnWeight=4), \\
@@ -6752,7 +6960,29 @@
 	SpawnDistribution[8]=(Template="SpectreM1", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 	SpawnDistribution[9]=(Template="SpectreM1", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=1), \\
 )
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="SpectreM1", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="SpectreM1", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+	SpawnDistribution[2]=(Template="SpectreM1", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="SpectreM1", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[4]=(Template="SpectreM1", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[5]=(Template="SpectreM1", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[6]=(Template="SpectreM1", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[7]=(Template="SpectreM1", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+)
 
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="SpectreM1", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="SpectreM1", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="SpectreM1", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="SpectreM1", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[4]=(Template="SpectreM1", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=1, SpawnWeight=5), \\
+	SpawnDistribution[5]=(Template="SpectreM1", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=1, SpawnWeight=6), \\
+	SpawnDistribution[6]=(Template="SpectreM1", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=1, SpawnWeight=4), \\
+	SpawnDistribution[7]=(Template="SpectreM1", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[8]=(Template="SpectreM1", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[9]=(Template="SpectreM1", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+)
 ;--------------------------
 ; SpectreM2
 ;
@@ -6805,6 +7035,20 @@
 )
 
 +SpawnDistributionLists=(ListID="Open", \\
+	SpawnDistribution[0]=(Template="SpectreM2", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[1]=(Template="SpectreM2", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="SpectreM2", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+)
++SpawnDistributionLists=(ListID="RendezvousOperatives_Leaders_LW", \\
+	SpawnDistribution[0]=(Template="SpectreM2", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="SpectreM2", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="SpectreM2", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="SpectreM2", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=1, SpawnWeight=3), \\
+	SpawnDistribution[4]=(Template="SpectreM2", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=1, SpawnWeight=2), \\
+	SpawnDistribution[5]=(Template="SpectreM2", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=1), \\
+)
+
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
 	SpawnDistribution[0]=(Template="SpectreM2", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 	SpawnDistribution[1]=(Template="SpectreM2", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=1, SpawnWeight=2), \\
 	SpawnDistribution[2]=(Template="SpectreM2", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=1, SpawnWeight=2), \\
@@ -6906,7 +7150,18 @@
 	SpawnDistribution[8]=(Template="Viper", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=4, SpawnWeight=1), \\
 	SpawnDistribution[9]=(Template="Viper", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=4, SpawnWeight=1), \\
 )
-
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="Viper", MinForceLevel=4, MaxForceLevel=4, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="Viper", MinForceLevel=5, MaxForceLevel=5, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="Viper", MinForceLevel=6, MaxForceLevel=6, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[3]=(Template="Viper", MinForceLevel=7, MaxForceLevel=7, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[4]=(Template="Viper", MinForceLevel=8, MaxForceLevel=8, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+	SpawnDistribution[5]=(Template="Viper", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[6]=(Template="Viper", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[7]=(Template="Viper", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[8]=(Template="Viper", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[9]=(Template="Viper", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+)
 ;--------------------------
 ; ViperM2_LW
 ;
@@ -7018,6 +7273,20 @@
 	SpawnDistribution[11]=(Template="ViperM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=1), \\
 )
 
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="ViperM2_LW", MinForceLevel=9, MaxForceLevel=9, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="ViperM2_LW", MinForceLevel=10, MaxForceLevel=10, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="ViperM2_LW", MinForceLevel=11, MaxForceLevel=11, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="ViperM2_LW", MinForceLevel=12, MaxForceLevel=12, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+	SpawnDistribution[4]=(Template="ViperM2_LW", MinForceLevel=13, MaxForceLevel=13, MaxCharactersPerGroup=4, SpawnWeight=5), \\
+	SpawnDistribution[5]=(Template="ViperM2_LW", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=4, SpawnWeight=4), \\
+	SpawnDistribution[6]=(Template="ViperM2_LW", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=4, SpawnWeight=3), \\
+	SpawnDistribution[7]=(Template="ViperM2_LW", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=4, SpawnWeight=2), \\
+	SpawnDistribution[8]=(Template="ViperM2_LW", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[9]=(Template="ViperM2_LW", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[10]=(Template="ViperM2_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+	SpawnDistribution[11]=(Template="ViperM2_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=1), \\
+)
 ;--------------------------
 ; ViperM3_LW
 ;
@@ -7105,7 +7374,15 @@
 	SpawnDistribution[6]=(Template="ViperM3_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=4, SpawnWeight=4), \\
 )
 
-
++SpawnDistributionLists=(ListID="RendezvousOperatives_LW", \\
+	SpawnDistribution[0]=(Template="ViperM3_LW", MinForceLevel=14, MaxForceLevel=14, MaxCharactersPerGroup=2, SpawnWeight=1), \\
+	SpawnDistribution[1]=(Template="ViperM3_LW", MinForceLevel=15, MaxForceLevel=15, MaxCharactersPerGroup=2, SpawnWeight=2), \\
+	SpawnDistribution[2]=(Template="ViperM3_LW", MinForceLevel=16, MaxForceLevel=16, MaxCharactersPerGroup=2, SpawnWeight=3), \\
+	SpawnDistribution[3]=(Template="ViperM3_LW", MinForceLevel=17, MaxForceLevel=17, MaxCharactersPerGroup=2, SpawnWeight=4), \\
+	SpawnDistribution[4]=(Template="ViperM3_LW", MinForceLevel=18, MaxForceLevel=18, MaxCharactersPerGroup=2, SpawnWeight=4), \\
+	SpawnDistribution[5]=(Template="ViperM3_LW", MinForceLevel=19, MaxForceLevel=19, MaxCharactersPerGroup=2, SpawnWeight=4), \\
+	SpawnDistribution[6]=(Template="ViperM3_LW", MinForceLevel=20, MaxForceLevel=99, MaxCharactersPerGroup=2, SpawnWeight=4), \\
+)
 ;--------------------------------
 ; Units used for Chosen Stronghold
 ;


### PR DESCRIPTION
Added Vipers, Sectoids and Spectres to the possible Rendezvous Operative spawns as both Leaders and Followers
Separated Officers/Sergeants (Leader only) from Trooper variants (Follower only) to ensure at least one corpse per pod is not a Trooper.  
Sectoid Commanders and Muton Centurions/ Elites can spawn as Leaders only (both to make endgame a bit harder in RV and because I do not see a regular Muton being stealthy enough for those missions)